### PR TITLE
Checker is a ClassValChecker and postAnalyze work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,8 @@ dependencies {
   // Testing
   testImplementation 'junit:junit:4.13.2'
   testImplementation "org.checkerframework:framework-test:${versions.checkerFramework}"
-  testImplementation group: 'com.google.inject', name: 'guice', version: '7.0.0'
-  testImplementation group: 'javax.inject', name: 'javax.inject', version: '1'
+  implementation group: 'com.google.inject', name: 'guice', version: '7.0.0'
+  implementation group: 'javax.inject', name: 'javax.inject', version: '1'
 
   errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 }

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionAnnotatedTypeFactory.java
@@ -1,18 +1,164 @@
 package org.checkerframework.checker.dependencyinjection;
 
+import com.sun.source.tree.Tree;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
+import org.checkerframework.common.reflection.ClassValAnnotatedTypeFactory;
 import org.checkerframework.dataflow.cfg.ControlFlowGraph;
+import org.checkerframework.dataflow.cfg.block.Block;
+import org.checkerframework.dataflow.cfg.node.MethodAccessNode;
+import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+import org.checkerframework.dataflow.cfg.node.Node;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.javacutil.TreeUtils;
 
-public class DependencyInjectionAnnotatedTypeFactory extends ValueAnnotatedTypeFactory {
+public class DependencyInjectionAnnotatedTypeFactory extends ClassValAnnotatedTypeFactory {
+
+  /** The {@code com.google.inject.AbstractModule.bind(Class<Baz> clazz)} method */
+  private final List<ExecutableElement> bindMethods = new ArrayList<>(3);
+
+  /** The {@code com.google.inject.binder.LinkedBindingBuilder.to(Class<? extends Baz> method */
+  private final List<ExecutableElement> toMethods = new ArrayList<>(3);
 
   public DependencyInjectionAnnotatedTypeFactory(BaseTypeChecker c) {
     super(c);
+    ProcessingEnvironment processingEnv = this.getProcessingEnv();
+    this.bindMethods.add(
+        TreeUtils.getMethod(
+            "com.google.inject.AbstractModule", "bind", processingEnv, "com.google.inject.Key<T>"));
+    this.bindMethods.add(
+        TreeUtils.getMethod(
+            "com.google.inject.AbstractModule",
+            "bind",
+            processingEnv,
+            "com.google.inject.TypeLiteral<T>"));
+    this.bindMethods.add(
+        TreeUtils.getMethod(
+            "com.google.inject.AbstractModule", "bind", processingEnv, "java.lang.Class<T>"));
+
+    this.toMethods.add(
+        TreeUtils.getMethod(
+            "com.google.inject.binder.LinkedBindingBuilder",
+            "to",
+            processingEnv,
+            "java.lang.Class<? extends T>"));
+    this.toMethods.add(
+        TreeUtils.getMethod(
+            "com.google.inject.binder.LinkedBindingBuilder",
+            "to",
+            processingEnv,
+            "com.google.inject.TypeLiteral<? extends T>"));
+    this.toMethods.add(
+        TreeUtils.getMethod(
+            "com.google.inject.binder.LinkedBindingBuilder",
+            "to",
+            processingEnv,
+            "com.google.inject.Key<? extends T>"));
     super.postInit();
+  }
+
+  /* Returns true iff the argument is an invocation of AbstractModule.bind.
+   *
+   * @param methodTree the method invocation tree
+   * @return true iff the argument is an invocation of AbstractModule.bind()
+   */
+  private boolean isBindMethod(Tree methodTree) {
+    return TreeUtils.isMethodInvocation(methodTree, this.bindMethods, this.getProcessingEnv());
+  }
+
+  /* Returns true iff the argument is an invocation of AbstractModule.to() */
+  private boolean isToMethod(Tree methodTree) {
+    return TreeUtils.isMethodInvocation(methodTree, this.toMethods, this.getProcessingEnv());
   }
 
   @Override
   protected void postAnalyze(ControlFlowGraph cfg) {
+
+    System.out.println("--------------------");
+
+    Set<Block> visited = new HashSet<>();
+    Deque<Block> worklist = new ArrayDeque<>();
+    HashMap<Integer, Integer> knownBindings = new HashMap<>();
+
+    Block entry = cfg.getEntryBlock();
+    worklist.add(entry);
+    visited.add(entry);
+
+    while (!worklist.isEmpty()) {
+      Block current = worklist.remove();
+
+      current
+          .getNodes()
+          .forEach(
+              node -> {
+                if (node instanceof MethodInvocationNode) {
+                  MethodInvocationNode methodInvocationNode = (MethodInvocationNode) node;
+
+                  System.out.printf("Method Invocation: %s\n", methodInvocationNode);
+                  System.out.printf("Operands: %s\n\n", methodInvocationNode.getOperands());
+
+                  if (methodInvocationNode.getOperands().size() >= 2) {
+                    MethodAccessNode methodAccessNode = methodInvocationNode.getTarget();
+                    Node fieldAccessNode = methodInvocationNode.getArgument(0);
+
+                    if (isBindMethod(methodInvocationNode.getTree())) {
+                      // Class that is being bound - put in knownBindings
+                      AnnotatedTypeMirror boundClassTypeMirror =
+                          this.getAnnotatedType(fieldAccessNode.getTree());
+
+                      knownBindings.put(boundClassTypeMirror.getUnderlyingTypeHashCode(), null);
+                    } else if (isToMethod(methodInvocationNode.getTree())) {
+                      Node receiver = methodAccessNode.getReceiver();
+
+                      // TODO: This feels a little hacky to get the bound class type mirror
+                      // Class that is being bound - should be in knownBindings
+                      AnnotatedTypeMirror boundClassTypeMirror =
+                          this.getAnnotatedType(
+                              receiver.getOperands().toArray(new Node[2])[1].getTree());
+
+                      if (knownBindings.containsKey(
+                          boundClassTypeMirror.getUnderlyingTypeHashCode())) {
+                        knownBindings.remove(boundClassTypeMirror.getUnderlyingTypeHashCode());
+                        // Class that is being bound to - put in knownBindings <bound, boundTo>
+                        AnnotatedTypeMirror boundToClassTypeMirror =
+                            this.getAnnotatedType(fieldAccessNode.getTree());
+                        knownBindings.put(
+                            boundClassTypeMirror.getUnderlyingTypeHashCode(),
+                            boundToClassTypeMirror.getUnderlyingTypeHashCode());
+                      }
+                    }
+                  }
+                }
+              });
+
+      current
+          .getSuccessors()
+          .forEach(
+              block -> {
+                if (!visited.contains(block)) {
+                  worklist.add(block);
+                }
+              });
+
+      System.out.println("Worklist");
+      worklist.forEach(block -> System.out.printf("Block: %s\n", block));
+      System.out.println("Visited");
+      visited.forEach(block -> System.out.printf("Block: %s\n", block));
+    }
+
+    knownBindings.forEach(
+        (key, value) -> {
+          System.out.printf("Key: %d, Value: %d\n", key, value);
+        });
+
     super.postAnalyze(cfg);
   }
 }

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionChecker.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionChecker.java
@@ -1,10 +1,10 @@
 package org.checkerframework.checker.dependencyinjection;
 
 import org.checkerframework.common.basetype.BaseTypeVisitor;
-import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.common.reflection.ClassValChecker;
 
 /** This is the entry point for pluggable type-checking. */
-public class DependencyInjectionChecker extends ValueChecker {
+public class DependencyInjectionChecker extends ClassValChecker {
 
   public DependencyInjectionChecker() {}
 

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionTransfer.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionTransfer.java
@@ -1,9 +1,9 @@
 package org.checkerframework.checker.dependencyinjection;
 
-import org.checkerframework.common.value.ValueTransfer;
 import org.checkerframework.framework.flow.CFAnalysis;
+import org.checkerframework.framework.flow.CFTransfer;
 
-public class DependencyInjectionTransfer extends ValueTransfer {
+public class DependencyInjectionTransfer extends CFTransfer {
 
   public DependencyInjectionTransfer(CFAnalysis analysis) {
     super(analysis);

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionVisitor.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionVisitor.java
@@ -1,9 +1,9 @@
 package org.checkerframework.checker.dependencyinjection;
 
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.common.value.ValueVisitor;
+import org.checkerframework.common.reflection.ClassValVisitor;
 
-public class DependencyInjectionVisitor extends ValueVisitor {
+public class DependencyInjectionVisitor extends ClassValVisitor {
 
   public DependencyInjectionVisitor(BaseTypeChecker c) {
     super(c);

--- a/tests/dependencyinjection/MissingImplementation.java
+++ b/tests/dependencyinjection/MissingImplementation.java
@@ -1,0 +1,96 @@
+package dependencyinjection;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import java.lang.annotation.Retention;
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+
+import org.checkerframework.common.value.qual.*;
+
+public class MissingImplementation {
+  @Qualifier
+  @Retention(RUNTIME)
+  @interface Message {}
+
+  @Qualifier
+  @Retention(RUNTIME)
+  @interface Count {}
+
+  /**
+   * Guice module that provides bindings for message and count used in
+   * {@link Greeter}.
+   */
+  static class DemoModule extends AbstractModule {
+    @Override
+    protected void configure() {
+      bind(Baz.class).to(BazImpl.class);
+    }
+
+    @Provides
+    @Count
+    static Integer provideCount() {
+      return 3;
+    }
+
+    @Provides
+    @Message
+    static String provideMessage() {
+      return "hello world";
+    }
+  }
+
+  static class Greeter {
+    private final String message;
+    private final int count;
+
+    // Greeter declares that it needs a string message and an integer
+    // representing the number of time the message to be printed.
+    // The @Inject annotation marks this constructor as eligible to be used by
+    // Guice.
+
+    Greeter(@Message String message, @Count int count) {
+      this.message = message;
+      this.count = count;
+    }
+
+    void sayHello() {
+      for (int i=0; i < count; i++) {
+        System.out.println(message);
+      }
+    }
+
+    String getMessage() {
+      return message;
+    }
+  }
+
+  interface Baz {
+    public void foo();
+  }
+
+  class BazImpl implements Baz {
+    public void foo() {
+      System.out.println("GuiceDemo.BazImpl.foo()");
+    }
+  }
+
+  public static void main(String args[]) {
+    /*
+     * Guice.createInjector() takes one or more modules, and returns a new Injector
+     * instance. Most applications will call this method exactly once, in their
+     * main() method.
+     */
+    Injector injector = Guice.createInjector(new DemoModule());
+    // :: error: MISSING_IMPLEMENTATION
+    Baz baz = injector.getInstance(BazImpl.class);
+
+    // :: error: MISSING_IMPLEMENTATION
+    Greeter greeter = injector.getInstance(Greeter.class);
+
+  }
+}

--- a/tests/dependencyinjection/SimpleMissingImplementation.java
+++ b/tests/dependencyinjection/SimpleMissingImplementation.java
@@ -1,0 +1,44 @@
+package dependencyinjection;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import javax.inject.Inject;
+
+import org.checkerframework.common.value.qual.*;
+
+public class SimpleMissingImplementation {
+
+  /**
+   * Guice module that provides bindings for message and count used in
+   * {@link Greeter}.
+   */
+  static class DemoModule extends AbstractModule {
+    @Override
+    protected void configure() {
+      bind(Baz.class).to(BazImpl.class);
+    }
+  }
+
+  interface Baz {
+    public void foo();
+  }
+
+  class BazImpl implements Baz {
+    public void foo() {
+      System.out.println("GuiceDemo.BazImpl.foo()");
+    }
+  }
+
+  public static void main(String args[]) {
+    /*
+     * Guice.createInjector() takes one or more modules, and returns a new Injector
+     * instance. Most applications will call this method exactly once, in their
+     * main() method.
+     */
+    Injector injector = Guice.createInjector(new DemoModule());
+    // :: error: MISSING_IMPLEMENTATION
+    Baz baz = injector.getInstance(BazImpl.class);
+  }
+}


### PR DESCRIPTION
There's a good amount of stuff in this commit.

As we discussed previously, I changed the checker to extend the `ClassValChecker`.

Additionally, `postAnalyze` can determine if a class has been bound to another class in an `AbstractModule`. It stores this relationship in the `knownBindings` hash map.
e.g., `bind(Baz.class).to(BazImpl.class);`

The example above works fine. However, I came across infinite loop behavior when dealing with more complex bindings and maybe you can look through the source code and find out what may be the issue. Running `./gradlew test` will present these issues to you.