### PR TITLE
Create a sub-checker that accumulates modules supported by an injector

### DIFF
--- a/src/main/java/org/checkerframework/checker/caninject/CanInject.astub
+++ b/src/main/java/org/checkerframework/checker/caninject/CanInject.astub
@@ -1,0 +1,26 @@
+import org.checkerframework.dataflow.qual.*;
+
+package com.google.inject;
+
+public final class Guice {
+    @Pure
+    public static Injector createInjector(Module... modules);
+    @Pure
+    public static Injector createInjector(Iterable<? extends Module> modules);
+    @Pure
+    public static Injector createInjector(Stage stage, Module... modules);
+    @Pure
+    public static Injector createInjector(Stage stage, Iterable<? extends Module> modules);
+}
+
+public interface Injector {
+    @Pure
+    void injectMembers(Object instance);
+}
+
+package com.google.inject.internal;
+
+public final class InternalInjectorCreator {
+    @Pure
+    public InternalInjectorCreator();
+}

--- a/src/main/java/org/checkerframework/checker/caninject/CanInjectAnnotatedTypeFactory.java
+++ b/src/main/java/org/checkerframework/checker/caninject/CanInjectAnnotatedTypeFactory.java
@@ -1,0 +1,68 @@
+package org.checkerframework.checker.caninject;
+
+import com.sun.source.tree.Tree;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.ExecutableElement;
+import org.checkerframework.checker.caninject.qual.CanInject;
+import org.checkerframework.checker.caninject.qual.CanInjectBottom;
+import org.checkerframework.common.accumulation.AccumulationAnnotatedTypeFactory;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.javacutil.TreeUtils;
+
+public class CanInjectAnnotatedTypeFactory extends AccumulationAnnotatedTypeFactory {
+
+  /** The fully-qualified name of the {@link com.google.inject.Guice} class */
+  private final String guiceName = "com.google.inject.Guice";
+
+  /** The {@link com.google.inject.Guice#createInjector method */
+  private final List<ExecutableElement> createInjectorMethods = new ArrayList<>(4);
+
+  /** Helper method that initializes Guice method elements */
+  private void initializeMethodElements() {
+    ProcessingEnvironment processingEnv = this.getProcessingEnv();
+    this.createInjectorMethods.add(
+        TreeUtils.getMethod(
+            guiceName, "createInjector", processingEnv, "com.google.inject.Module[]"));
+    this.createInjectorMethods.add(
+        TreeUtils.getMethod(
+            guiceName,
+            "createInjector",
+            processingEnv,
+            "java.lang.Iterable<? extends com.google.inject.Module>"));
+    this.createInjectorMethods.add(
+        TreeUtils.getMethod(
+            guiceName,
+            "createInjector",
+            processingEnv,
+            "com.google.inject.Stage",
+            "com.google.inject.Module[]"));
+    this.createInjectorMethods.add(
+        TreeUtils.getMethod(
+            guiceName,
+            "createInjector",
+            processingEnv,
+            "com.google.inject.Stage",
+            "java.lang.Iterable<? extends com.google.inject.Module>"));
+  }
+
+  public CanInjectAnnotatedTypeFactory(BaseTypeChecker checker) {
+    super(checker, CanInject.class, CanInjectBottom.class);
+    this.initializeMethodElements();
+    this.postInit();
+  }
+
+  /**
+   * Returns true iff the argument is an invocation of {@link
+   * com.google.inject.Guice#createInjector}.
+   *
+   * @param methodTree the method invocation tree
+   * @return true iff the argument is an invocation of {@link
+   *     com.google.inject.Guice#createInjector}
+   */
+  protected boolean isCreateInjectorMethod(Tree methodTree) {
+    return TreeUtils.isMethodInvocation(
+        methodTree, this.createInjectorMethods, this.getProcessingEnv());
+  }
+}

--- a/src/main/java/org/checkerframework/checker/caninject/CanInjectChecker.java
+++ b/src/main/java/org/checkerframework/checker/caninject/CanInjectChecker.java
@@ -1,0 +1,17 @@
+package org.checkerframework.checker.caninject;
+
+import org.checkerframework.common.accumulation.AccumulationChecker;
+import org.checkerframework.common.basetype.BaseTypeVisitor;
+import org.checkerframework.framework.qual.StubFiles;
+
+/** This is the entry point for pluggable type-checking. */
+@StubFiles({"CanInject.astub"})
+public class CanInjectChecker extends AccumulationChecker {
+
+  public CanInjectChecker() {}
+
+  @Override
+  protected BaseTypeVisitor<?> createSourceVisitor() {
+    return new CanInjectVisitor(this);
+  }
+}

--- a/src/main/java/org/checkerframework/checker/caninject/CanInjectTransfer.java
+++ b/src/main/java/org/checkerframework/checker/caninject/CanInjectTransfer.java
@@ -1,0 +1,54 @@
+package org.checkerframework.checker.caninject;
+
+import java.util.List;
+import org.checkerframework.common.accumulation.AccumulationTransfer;
+import org.checkerframework.dataflow.analysis.TransferInput;
+import org.checkerframework.dataflow.analysis.TransferResult;
+import org.checkerframework.dataflow.cfg.node.ArrayCreationNode;
+import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
+import org.checkerframework.dataflow.cfg.node.Node;
+import org.checkerframework.framework.flow.CFAnalysis;
+import org.checkerframework.framework.flow.CFStore;
+import org.checkerframework.framework.flow.CFValue;
+import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.TreeUtils;
+
+public class CanInjectTransfer extends AccumulationTransfer {
+
+  public CanInjectTransfer(CFAnalysis analysis) {
+    super(analysis);
+  }
+
+  @Override
+  public TransferResult<CFValue, CFStore> visitMethodInvocation(
+      final MethodInvocationNode node, final TransferInput<CFValue, CFStore> input) {
+
+    TransferResult<CFValue, CFStore> result = super.visitMethodInvocation(node, input);
+
+    CanInjectAnnotatedTypeFactory atf = (CanInjectAnnotatedTypeFactory) analysis.getTypeFactory();
+
+    if (atf.isCreateInjectorMethod(node.getTree())) {
+      ArrayCreationNode argumentNode = (ArrayCreationNode) node.getArgument(0);
+      List<Node> modules = argumentNode.getInitializers();
+
+      System.out.println("node");
+      System.out.println();
+      modules.forEach(
+          module -> {
+            System.out.println("module");
+            System.out.println(module);
+            System.out.println();
+            String moduleFullyQualifiedName =
+                ElementUtils.getQualifiedClassName(TreeUtils.elementFromTree(module.getTree()))
+                    .toString();
+
+            System.out.println(result);
+            System.out.println();
+            this.accumulate(node, result, moduleFullyQualifiedName);
+            System.out.println(result);
+          });
+    }
+
+    return result;
+  }
+}

--- a/src/main/java/org/checkerframework/checker/caninject/CanInjectVisitor.java
+++ b/src/main/java/org/checkerframework/checker/caninject/CanInjectVisitor.java
@@ -1,0 +1,10 @@
+package org.checkerframework.checker.caninject;
+
+import org.checkerframework.common.accumulation.AccumulationVisitor;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+
+public class CanInjectVisitor extends AccumulationVisitor {
+  public CanInjectVisitor(BaseTypeChecker checker) {
+    super(checker);
+  }
+}

--- a/src/main/java/org/checkerframework/checker/caninject/qual/CanInject.java
+++ b/src/main/java/org/checkerframework/checker/caninject/qual/CanInject.java
@@ -1,0 +1,33 @@
+package org.checkerframework.checker.caninject.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
+import org.checkerframework.framework.qual.SubtypeOf;
+
+/**
+ * Represents fully-qualified class names that have been passed as arguments to {@link
+ * com.google.inject.Guice#createInjector}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
+public @interface CanInject {
+  /** The fully-qualified name of this annotation. */
+  static final String NAME = "org.checkerframework.checker.caninject.qual.CanInject";
+  /**
+   * Class names that have definitely been passed as an argument to a {@link
+   * com.google.inject.Guice#createInjector} call.
+   *
+   * <p>The arguments are "fully qualified binary names" ({@link
+   * org.checkerframework.checker.signature.qual.FqBinaryName}): a primitive or <a
+   * href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-13.html#jls-13.1">binary name</a>.
+   *
+   * @return classes that have definitely been passed as an argument to {@link
+   *     com.google.inject.Guice#createInjector}
+   */
+  public String[] value() default {};
+}

--- a/src/main/java/org/checkerframework/checker/caninject/qual/CanInjectBottom.java
+++ b/src/main/java/org/checkerframework/checker/caninject/qual/CanInjectBottom.java
@@ -1,0 +1,20 @@
+package org.checkerframework.checker.caninject.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
+
+/**
+ * The bottom type for the CanInject type system.
+ *
+ * <p>It should rarely be written by a programmer.
+ */
+@SubtypeOf({CanInject.class})
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+public @interface CanInjectBottom {}

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionChecker.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionChecker.java
@@ -2,8 +2,8 @@ package org.checkerframework.checker.dependencyinjection;
 
 import java.util.LinkedHashSet;
 import java.util.Map;
-import javax.lang.model.element.Element;
-import org.checkerframework.checker.dependencyinjection.utils.KnownBindingsValue;
+import org.checkerframework.checker.caninject.CanInjectChecker;
+import org.checkerframework.checker.dependencyinjection.utils.Module;
 import org.checkerframework.common.accumulation.AccumulationChecker;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
@@ -26,29 +26,43 @@ public class DependencyInjectionChecker extends AccumulationChecker {
     LinkedHashSet<Class<? extends BaseTypeChecker>> checkers =
         super.getImmediateSubcheckerClasses();
     checkers.add(ClassValChecker.class);
+    checkers.add(CanInjectChecker.class);
 
     return checkers;
   }
 
   @Override
   public void typeProcessingOver() {
-    Map<String, KnownBindingsValue> knownBindings =
-        DependencyInjectionAnnotatedTypeFactory.getKnownBindings();
-    Map<String, Element> injectionPoints =
-        DependencyInjectionAnnotatedTypeFactory.getInjectionPoints();
+    Map<String, Module> modules = DependencyInjectionAnnotatedTypeFactory.getModules();
+    modules.forEach(
+        (moduleName, module) -> {
+          System.out.println(moduleName);
+          module
+              .getBindings()
+              .forEach(
+                  (dependencyName, knownBindingsValue) -> {
+                    System.out.println("\t" + dependencyName + " -> " + knownBindingsValue);
+                  });
+          System.out.println();
+        });
+    // Map<String, KnownBindingsValue> knownBindings =
+    //     DependencyInjectionAnnotatedTypeFactory.getModules();
+    // Map<String, Element> injectionPoints =
+    //     DependencyInjectionAnnotatedTypeFactory.getInjectionPoints();
 
-    injectionPoints
-        .entrySet()
-        .forEach(
-            (injectionPoint) -> {
-              if (!knownBindings.containsKey(injectionPoint.getKey())) {
-                reportError(
-                    injectionPoint.getValue(), "missing.implementation", injectionPoint.getKey());
-              }
-            });
+    // injectionPoints
+    //     .entrySet()
+    //     .forEach(
+    //         (injectionPoint) -> {
+    //           if (!knownBindings.containsKey(injectionPoint.getKey())) {
+    //             reportError(
+    //                 injectionPoint.getValue(), "missing.implementation",
+    // injectionPoint.getKey());
+    //           }
+    //         });
 
-    DependencyInjectionAnnotatedTypeFactory.printKnownBindings();
-    DependencyInjectionAnnotatedTypeFactory.printDependencies();
+    // DependencyInjectionAnnotatedTypeFactory.printKnownBindings();
+    // DependencyInjectionAnnotatedTypeFactory.printDependencies();
 
     super.typeProcessingOver();
   }

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionTransfer.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionTransfer.java
@@ -38,6 +38,10 @@ public class DependencyInjectionTransfer extends AccumulationTransfer {
     if (diATF.isBindMethod(node.getTree())) {
       Node boundClass = node.getArgument(0);
 
+      System.out.println("DependencyInjectionTransfer.visitMethodInvocation()");
+      System.out.println(node);
+      System.out.println();
+
       AnnotatedTypeMirror boundClassTypeMirror =
           this.diATF
               .getTypeFactoryOfSubchecker(ClassValChecker.class)
@@ -48,12 +52,15 @@ public class DependencyInjectionTransfer extends AccumulationTransfer {
               boundClassTypeMirror.getAnnotation(), diATF.classValValueElement, String.class);
 
       classNames.forEach(
-          className ->
-              accumulate(
-                  node,
-                  result,
-                  DependencyInjectionAnnotatedTypeFactory.resolveInjectionPointClassName(
-                      className)));
+          className -> {
+            System.out.println(result);
+            System.out.println();
+            accumulate(
+                node,
+                result,
+                DependencyInjectionAnnotatedTypeFactory.resolveInjectionPointClassName(className));
+            System.out.println(result);
+          });
 
     } else if (diATF.isAnnotatedWithMethod(node.getTree())) {
 

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionVisitor.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/DependencyInjectionVisitor.java
@@ -7,6 +7,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.dependencyinjection.utils.KnownBindingsValue;
+import org.checkerframework.checker.dependencyinjection.utils.Module;
 import org.checkerframework.common.accumulation.AccumulationVisitor;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.javacutil.ElementUtils;
@@ -43,9 +44,21 @@ public class DependencyInjectionVisitor extends AccumulationVisitor {
           DependencyInjectionAnnotatedTypeFactory.resolveInjectionPointClassName(
               element.getReturnType());
 
-      DependencyInjectionAnnotatedTypeFactory.addBinding(
-          resolvedTypeKindString,
-          KnownBindingsValue.builder().className(resolvedTypeKindString).build());
+      String enclosingModuleQualifiedName = ElementUtils.getQualifiedClassName(element).toString();
+
+      if (!DependencyInjectionAnnotatedTypeFactory.containsModule(enclosingModuleQualifiedName)) {
+        Module module = new Module();
+        module.addBinding(
+            resolvedTypeKindString,
+            KnownBindingsValue.builder().className(resolvedTypeKindString).build());
+        DependencyInjectionAnnotatedTypeFactory.addModule(enclosingModuleQualifiedName, module);
+      } else {
+        Module module =
+            DependencyInjectionAnnotatedTypeFactory.getModule(enclosingModuleQualifiedName);
+        module.addBinding(
+            resolvedTypeKindString,
+            KnownBindingsValue.builder().className(resolvedTypeKindString).build());
+      }
     }
     return super.visitMethod(tree, p);
   }

--- a/src/main/java/org/checkerframework/checker/dependencyinjection/utils/Module.java
+++ b/src/main/java/org/checkerframework/checker/dependencyinjection/utils/Module.java
@@ -1,0 +1,62 @@
+package org.checkerframework.checker.dependencyinjection.utils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A class that represents a {@link com.google.inject.AbstractModule} defined in the program as a
+ * map of its bindings.
+ */
+public class Module {
+  /**
+   * The map of <a href="https://github.com/google/guice/wiki/Bindings#bindings">bindings</a> that
+   * the program may compute at run time for this particular module. Bindings are configured in
+   * {@link com.google.inject.AbstractModule}. If a dependency does exist in this map, it has
+   * definitely been properly defined or configured. Otherwise, it may or may not have been properly
+   * defined or configured.
+   *
+   * <p>The key is the fully-qualified class name of the class being bound.
+   *
+   * <p>The value is the {@link KnownBindingsValue} that represents the class that has been bound
+   * to.
+   */
+  private HashMap<String, KnownBindingsValue> bindings;
+
+  public Module() {
+    this.bindings = new HashMap<>();
+  }
+
+  /**
+   * Adds a known binding to the map of bindings.
+   *
+   * @param dependencyName the fully-qualified class name of the dependency
+   * @param knownBindingsValue the value of the known binding, containing the fully-qualified class
+   *     name of the class that the dependency is bound to and the optional annotation name
+   */
+  public void addBinding(String dependencyName, KnownBindingsValue knownBindingsValue) {
+    this.bindings.put(dependencyName, knownBindingsValue);
+  }
+
+  /**
+   * Removes a known binding from the map of bindings.
+   *
+   * @param dependencyName the fully-qualified class name of the dependency
+   */
+  public void removeBinding(String dependencyName) {
+    this.bindings.remove(dependencyName);
+  }
+
+  /**
+   * Returns the map of bindings.
+   *
+   * @return the map of bindings
+   */
+  public Map<String, KnownBindingsValue> getBindings() {
+    return Collections.unmodifiableMap(this.bindings);
+  }
+
+  public boolean containsBinding(String dependencyName) {
+    return this.bindings.containsKey(dependencyName);
+  }
+}


### PR DESCRIPTION
The purpose of this PR is to give the checker the ability to determine if an injector is capable of resolving a dependency.

Injectors can be defined and used like so:

```java
    Injector injector = Guice.createInjector(new DemoModule());

    Baz baz = injector.getInstance(Baz.class);
```

We currently keep track of the bindings defined within `DemoModule`, but we have no idea which modules, (`DemoModule`), are tied to `injector`.

Therefore, when we come across `injector.getInstance(Baz.class);`, we won't know what to do.

The solution here is to create a subchecker that accumulates the modules that any injector can inject, hence `CanInject`.

The issue I'm currently facing is actually accumulating these values. The annotation itself is made, but it doesn't persist in the store and it reminds me of an issue we faced a few months back that dealt with determinism.